### PR TITLE
Feature - wait_for_endpoint() valid status codes range

### DIFF
--- a/sherpa/utils/http.py
+++ b/sherpa/utils/http.py
@@ -38,14 +38,16 @@ def to_base64_creds(user, password):
 	return base64_bytes.decode('ascii')
 
 
-def wait_for_endpoint(url, iterations, interval, logger, headers={}, verify=True):
+def wait_for_endpoint(url, iterations, interval, logger, headers={}, valid_status_code_range = range(200, 300), verify=True):
 	"""
 	Wait for a http endpoint until is up and running
-	:param headers: http headers
 	:param url: http endpoint
 	:param iterations: number of retries
 	:param interval: waiting interval between retries
 	:param logger: sherpa log obj
+	:param headers: http headers
+	:param valid_status_codes: range to expect resulting status code to be within
+	:param verify: certificate validation (gets passed onto requests.request())
 	:return: None
 	"""
 	endpoint_ready = False
@@ -57,7 +59,7 @@ def wait_for_endpoint(url, iterations, interval, logger, headers={}, verify=True
 			logger.trace("http_response: {}, type: {}", http_response, type(http_response))
 			response_code = http_response.status_code
 			logger.trace("response_code: {}, type: {}", response_code, type(response_code))
-			if 200 <= response_code < 300:
+			if response_code in valid_status_code_range:
 				endpoint_ready = True
 				break
 		except:

--- a/testing/test_http.py
+++ b/testing/test_http.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+import os
+import shutil
+import sys
+
+sys.path.insert(1, "../")
+from sherpa.utils.basics import Logger
+from sherpa.utils.basics import Properties
+from sherpa.utils.http import wait_for_endpoint
+
+
+def main():
+	properties = Properties("default.properties", "local.properties", "$(", ")")
+	logger = Logger(os.path.basename(__file__), properties.get("log_level"), properties.get("log_file"))
+	run(logger)
+	logger.info("{} finished.".format(os.path.basename(__file__)))
+
+
+def test_wait_for_endpoint(logger):
+	wait_for_endpoint(
+		url="https://identicum.com",
+		iterations=2,
+		interval=10,
+		logger=logger,
+		valid_status_code_range=range(200, 399)
+	)
+
+
+def run(logger):
+	logger.info("{} starting.".format(os.path.basename(__file__)))
+	test_wait_for_endpoint(logger)
+
+
+if __name__ == "__main__":
+	sys.exit(main())
+


### PR DESCRIPTION
Added a new optional parameter to wait_for_endpoint to set a custom range of acceptable http status codes