### PR TITLE
Have Logger methods return the output line

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup
 
 setup(
     name='sherpa-py-utils',
-    version='1.0.20260327',
+    version='1.0.20260412',
     description='Python utilities on Identicum projects',
     url='git@github.com:Identicum/sherpa-py-utils.git',
     author='Identicum',

--- a/sherpa/utils/basics.py
+++ b/sherpa/utils/basics.py
@@ -34,35 +34,35 @@ class Logger(object):
         TRACE log
         :param msg: msg to log
         """
-        self._log("TRACE", msg, *args)
+        return self._log("TRACE", msg, *args)
 
     def debug(self, msg, *args):
         """
         DEBUG log
         :param msg: msg to log
         """
-        self._log("DEBUG", msg, *args)
+        return self._log("DEBUG", msg, *args)
 
     def info(self, msg, *args):
         """
         INFO log
         :param msg: msg to log
         """
-        self._log("INFO", msg, *args)
+        return self._log("INFO", msg, *args)
 
     def warn(self, msg, *args):
         """
         WARN log
         :param msg: msg to log
         """
-        self._log("WARN", msg, *args)
+        return self._log("WARN", msg, *args)
 
     def error(self, msg, *args):
         """
         ERROR log
         :param msg: msg to log
         """
-        self._log("ERROR", msg, *args)
+        return self._log("ERROR", msg, *args)
 
     def _log(self, function_log_level, msg, *args):
         """
@@ -83,6 +83,8 @@ class Logger(object):
                 f.close()
             except Exception:
                 pass
+            return log_line
+        return None
 
     def _log_level(self, argument):
         """


### PR DESCRIPTION
Have Logger methods to return the output line, so those can be reused in the calling context.
Needed in https://github.com/Identicum/playwright to include tests logging into the JSON report.